### PR TITLE
Add CORS route that return 200 on OPTIONS calls

### DIFF
--- a/src/Teapot.Web/Controllers/StatusController.cs
+++ b/src/Teapot.Web/Controllers/StatusController.cs
@@ -3,6 +3,7 @@ using Teapot.Web.Models;
 
 namespace Teapot.Web.Controllers
 {
+    [CorsAllowAnyOrigin]
     public class StatusController : Controller
     {
         static readonly StatusCodeResults StatusCodes = new StatusCodeResults();
@@ -19,6 +20,18 @@ namespace Teapot.Web.Controllers
                 : new StatusCodeResult {Description = string.Format("{0} Unknown Code", statusCode)};
 
             return new CustomHttpStatusCodeResult(statusCode, statusData);
+        }
+    }
+
+    public class CorsAllowAnyOriginAttribute : ActionFilterAttribute
+    {
+        public override void OnResultExecuted(ResultExecutedContext filterContext)
+        {
+            if (filterContext.HttpContext.Response.Headers["Access-Control-Allow-Origin"] == null)
+            {
+                filterContext.HttpContext.Response.Headers.Add("Access-Control-Allow-Origin", "*");
+            }
+            base.OnResultExecuted(filterContext);
         }
     }
 }

--- a/src/Teapot.Web/Controllers/StatusController.cs
+++ b/src/Teapot.Web/Controllers/StatusController.cs
@@ -1,4 +1,6 @@
-﻿using System.Web.Mvc;
+﻿using System.Collections.Generic;
+using System.Net;
+using System.Web.Mvc;
 using Teapot.Web.Models;
 
 namespace Teapot.Web.Controllers
@@ -20,6 +22,28 @@ namespace Teapot.Web.Controllers
                 : new StatusCodeResult {Description = string.Format("{0} Unknown Code", statusCode)};
 
             return new CustomHttpStatusCodeResult(statusCode, statusData);
+        }
+
+        public ActionResult Cors(int statusCode)
+        {
+            if (Request.HttpMethod != "OPTIONS")
+            {
+                return StatusCode(statusCode);
+            }
+
+            var allowedOrigin = Request.Headers.Get("Origin") ?? "*";
+            var allowedMethod = Request.Headers.Get("Access-Control-Request-Method") ?? "GET";
+            var allowedHeaders = Request.Headers.Get("Access-Control-Request-Headers") ?? "X-Anything";
+
+            var responseHeaders = new Dictionary<string, string>
+            {
+                { "Access-Control-Allow-Origin", allowedOrigin },
+                { "Access-Control-Allow-Headers", allowedHeaders },
+                { "Access-Control-Allow-Methods", allowedMethod }
+            };
+
+            var statusData = new StatusCodeResult { IncludeHeaders = responseHeaders };
+            return new CustomHttpStatusCodeResult((int)HttpStatusCode.OK, statusData);
         }
     }
 

--- a/src/Teapot.Web/Controllers/StatusController.cs
+++ b/src/Teapot.Web/Controllers/StatusController.cs
@@ -46,16 +46,4 @@ namespace Teapot.Web.Controllers
             return new CustomHttpStatusCodeResult((int)HttpStatusCode.OK, statusData);
         }
     }
-
-    public class CorsAllowAnyOriginAttribute : ActionFilterAttribute
-    {
-        public override void OnResultExecuted(ResultExecutedContext filterContext)
-        {
-            if (filterContext.HttpContext.Response.Headers["Access-Control-Allow-Origin"] == null)
-            {
-                filterContext.HttpContext.Response.Headers.Add("Access-Control-Allow-Origin", "*");
-            }
-            base.OnResultExecuted(filterContext);
-        }
-    }
 }

--- a/src/Teapot.Web/CorsAllowAnyOriginAttribute.cs
+++ b/src/Teapot.Web/CorsAllowAnyOriginAttribute.cs
@@ -1,0 +1,16 @@
+using System.Web.Mvc;
+
+namespace Teapot.Web
+{
+    public class CorsAllowAnyOriginAttribute : ActionFilterAttribute
+    {
+        public override void OnResultExecuted(ResultExecutedContext filterContext)
+        {
+            if (filterContext.HttpContext.Response.Headers["Access-Control-Allow-Origin"] == null)
+            {
+                filterContext.HttpContext.Response.Headers.Add("Access-Control-Allow-Origin", "*");
+            }
+            base.OnResultExecuted(filterContext);
+        }
+    }
+}

--- a/src/Teapot.Web/Global.asax.cs
+++ b/src/Teapot.Web/Global.asax.cs
@@ -36,16 +36,6 @@ namespace Teapot.Web
                 new { controller = "Status", action = "Index" } // Parameter defaults
             );
         }
-        
-        protected void Application_BeginRequest(object sender, EventArgs e)
-        {
-            HttpApplication application = (HttpApplication)sender;
-            HttpContext context = application.Context;
-            
-            context.Response.setHeader("Access-Control-Allow-Origin", "*");
-            // Complete.
-            base.CompleteRequest();
-        }
 
         protected void Application_Start()
         {

--- a/src/Teapot.Web/Global.asax.cs
+++ b/src/Teapot.Web/Global.asax.cs
@@ -31,6 +31,13 @@ namespace Teapot.Web
             );
 
             routes.MapRoute(
+                "Cors",
+                "{statusCode}/cors",
+                new { controller = "Status", action = "Cors" },
+                new { statusCode = @"\d{3}" }
+            );
+
+            routes.MapRoute(
                 "Default", // Route name
                 "{controller}/{action}", // URL with parameters
                 new { controller = "Status", action = "Index" } // Parameter defaults

--- a/src/Teapot.Web/Teapot.Web.csproj
+++ b/src/Teapot.Web/Teapot.Web.csproj
@@ -98,6 +98,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CorsAllowAnyOriginAttribute.cs" />
     <Compile Include="Controllers\TeapotController.cs" />
     <Compile Include="CustomHttpStatusCodeResult.cs" />
     <Compile Include="Controllers\StatusController.cs" />

--- a/src/Teapot.Web/Web.config
+++ b/src/Teapot.Web/Web.config
@@ -17,11 +17,6 @@
     <validation validateIntegratedModeConfiguration="false" />
     <modules runAllManagedModulesForAllRequests="true" />
     <httpErrors errorMode="DetailedLocalOnly" existingResponse="PassThrough" />
-    <httpProtocol>
-      <customHeaders>
-        <add name="Access-Control-Allow-Origin" value="*" />
-      </customHeaders>
-    </httpProtocol>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">


### PR DESCRIPTION
This is for https://github.com/Readify/httpstatus/issues/25

I've added a new route that will match `http://httpstat.us/400/cors` and return 200 for any OPTIONS requests and the expected status code for anything else.

It turns out that this was always putting an allowed origin of "\*" on the responses so I've kept that but moved it into code rather than the web.config because otherwise IIS will append it and you can end up with "*, *".

Sorry this took a while, I kind of forgot about it for a bit there.
