### PR TITLE
Adding an optional parameter "sleep"

### DIFF
--- a/src/Teapot.Web/Controllers/StatusController.cs
+++ b/src/Teapot.Web/Controllers/StatusController.cs
@@ -15,20 +15,22 @@ namespace Teapot.Web.Controllers
             return View(StatusCodes);
         }
 
-        public ActionResult StatusCode(int statusCode)
+        public ActionResult StatusCode(int statusCode, int? sleep = 0)
         {
             var statusData = StatusCodes.ContainsKey(statusCode)
                 ? StatusCodes[statusCode]
                 : new StatusCodeResult {Description = string.Format("{0} Unknown Code", statusCode)};
 
+            System.Threading.Thread.Sleep(sleep.Value);
+
             return new CustomHttpStatusCodeResult(statusCode, statusData);
         }
 
-        public ActionResult Cors(int statusCode)
+        public ActionResult Cors(int statusCode, int? sleep=0)
         {
             if (Request.HttpMethod != "OPTIONS")
             {
-                return StatusCode(statusCode);
+                return StatusCode(statusCode, sleep);
             }
 
             var allowedOrigin = Request.Headers.Get("Origin") ?? "*";


### PR DESCRIPTION
Adding an optional parameter "sleep" to delay response. 

E.g. usage:

http://server-name/400?sleep=5000

This will respond with 400 status code after waiting 5000 milliseconds (plus any network delays)

http://server-name/400
This will respond with 400 status code immediately
