### PR TITLE
Adding optional parameter "sleep" with min and max limits

### DIFF
--- a/src/Teapot.Web/Controllers/StatusController.cs
+++ b/src/Teapot.Web/Controllers/StatusController.cs
@@ -10,15 +10,15 @@ namespace Teapot.Web.Controllers
     {
         static readonly StatusCodeResults StatusCodes = new StatusCodeResults();
 
-        private static readonly int SLEEP_MIN = 0;
-        private static readonly int SLEEP_MAX = 300000; // 5 mins in milliseconds
+        private const int SLEEP_MIN = 0;
+        private const int SLEEP_MAX = 300000; // 5 mins in milliseconds
 
         public ActionResult Index()
         {
             return View(StatusCodes);
         }
 
-        public ActionResult StatusCode(int statusCode, int? sleep = 0)
+        public ActionResult StatusCode(int statusCode, int? sleep = SLEEP_MIN)
         {
             var statusData = StatusCodes.ContainsKey(statusCode)
                 ? StatusCodes[statusCode]
@@ -29,7 +29,7 @@ namespace Teapot.Web.Controllers
             return new CustomHttpStatusCodeResult(statusCode, statusData);
         }
 
-        public ActionResult Cors(int statusCode, int? sleep=0)
+        public ActionResult Cors(int statusCode, int? sleep = SLEEP_MIN)
         {
             if (Request.HttpMethod != "OPTIONS")
             {
@@ -64,11 +64,6 @@ namespace Teapot.Web.Controllers
             }
         }
 
-        /// <summary>
-        /// Limits the sleep parameter 
-        /// </summary>
-        /// <param name="sleep"></param>
-        /// <returns></returns>
         private static int SanitizeSleepParameter(int? sleep, int min, int max)
         {
             var sleepData = sleep ?? 0;

--- a/src/Teapot.Web/Controllers/StatusController.cs
+++ b/src/Teapot.Web/Controllers/StatusController.cs
@@ -22,14 +22,9 @@ namespace Teapot.Web.Controllers
         {
             var statusData = StatusCodes.ContainsKey(statusCode)
                 ? StatusCodes[statusCode]
-                : new StatusCodeResult {Description = string.Format("{0} Unknown Code", statusCode) };
+                : new StatusCodeResult { Description = string.Format("{0} Unknown Code", statusCode) };
 
-            int sleepData = SanitizeSleepParameter(sleep, SLEEP_MIN, SLEEP_MAX);
-
-            if (sleepData > 0)
-            {
-                System.Threading.Thread.Sleep(sleepData);
-            }
+            DoSleep(sleep);
 
             return new CustomHttpStatusCodeResult(statusCode, statusData);
         }
@@ -54,14 +49,19 @@ namespace Teapot.Web.Controllers
 
             var statusData = new StatusCodeResult { IncludeHeaders = responseHeaders };
 
+            DoSleep(sleep);
+
+            return new CustomHttpStatusCodeResult((int)HttpStatusCode.OK, statusData);
+        }
+
+        private static void DoSleep(int? sleep)
+        {
             int sleepData = SanitizeSleepParameter(sleep, SLEEP_MIN, SLEEP_MAX);
 
             if (sleepData > 0)
             {
                 System.Threading.Thread.Sleep(sleepData);
             }
-
-            return new CustomHttpStatusCodeResult((int)HttpStatusCode.OK, statusData);
         }
 
         /// <summary>

--- a/src/Teapot.Web/Controllers/StatusController.cs
+++ b/src/Teapot.Web/Controllers/StatusController.cs
@@ -22,7 +22,7 @@ namespace Teapot.Web.Controllers
         {
             var statusData = StatusCodes.ContainsKey(statusCode)
                 ? StatusCodes[statusCode]
-                : new StatusCodeResult { Description = string.Format("{0} Unknown Code", statusCode) };
+                : new StatusCodeResult {Description = string.Format("{0} Unknown Code", statusCode) };
 
             int sleepData = SanitizeSleepParameter(sleep, SLEEP_MIN, SLEEP_MAX);
 
@@ -32,30 +32,6 @@ namespace Teapot.Web.Controllers
             }
 
             return new CustomHttpStatusCodeResult(statusCode, statusData);
-        }
-
-        /// <summary>
-        /// Limits the sleep parameter 
-        /// </summary>
-        /// <param name="sleep"></param>
-        /// <returns></returns>
-        private static int SanitizeSleepParameter(int? sleep, int min, int max)
-        {
-            var sleepData = sleep ?? 0;
-
-            // range check - minimum should be 0
-            if (sleepData < min)
-            {
-                sleepData = min;
-            }
-
-            // range check- maximum should be 300000 (5 mins)
-            if (sleepData > max)
-            {
-                sleepData = max;
-            }
-
-            return sleepData;
         }
 
         public ActionResult Cors(int statusCode, int? sleep=0)
@@ -86,6 +62,30 @@ namespace Teapot.Web.Controllers
             }
 
             return new CustomHttpStatusCodeResult((int)HttpStatusCode.OK, statusData);
+        }
+
+        /// <summary>
+        /// Limits the sleep parameter 
+        /// </summary>
+        /// <param name="sleep"></param>
+        /// <returns></returns>
+        private static int SanitizeSleepParameter(int? sleep, int min, int max)
+        {
+            var sleepData = sleep ?? 0;
+
+            // range check - minimum should be 0
+            if (sleepData < min)
+            {
+                sleepData = min;
+            }
+
+            // range check- maximum should be 300000 (5 mins)
+            if (sleepData > max)
+            {
+                sleepData = max;
+            }
+
+            return sleepData;
         }
     }
 }

--- a/src/Teapot.Web/Controllers/StatusController.cs
+++ b/src/Teapot.Web/Controllers/StatusController.cs
@@ -15,20 +15,22 @@ namespace Teapot.Web.Controllers
             return View(StatusCodes);
         }
 
-        public ActionResult StatusCode(int statusCode)
+        public ActionResult StatusCode(int statusCode, int? sleep = 0)
         {
             var statusData = StatusCodes.ContainsKey(statusCode)
                 ? StatusCodes[statusCode]
                 : new StatusCodeResult {Description = string.Format("{0} Unknown Code", statusCode)};
 
+            System.Threading.Thread.Sleep(sleep.Value);
+
             return new CustomHttpStatusCodeResult(statusCode, statusData);
         }
 
-        public ActionResult Cors(int statusCode)
+        public ActionResult Cors(int statusCode, int? sleep=0)
         {
             if (Request.HttpMethod != "OPTIONS")
             {
-                return StatusCode(statusCode);
+                return StatusCode(statusCode, sleep);
             }
 
             var allowedOrigin = Request.Headers.Get("Origin") ?? "*";


### PR DESCRIPTION
Adding optional parameter "sleep" with min and max limits of 0 and 300000 (5 mins).

E.g. usage:
http://server-name/400?sleep=5000
This will return HTTP 400 after 5 seconds 

http://server-name/400
This will return HTTP 400 immediatly