### PR TITLE
Use secure https in Location URLs for redirects

### DIFF
--- a/src/Teapot.Web/Controllers/TeapotController.cs
+++ b/src/Teapot.Web/Controllers/TeapotController.cs
@@ -6,7 +6,7 @@ namespace Teapot.Web.Controllers
     {
         public ActionResult Teapot()
         {
-            return Redirect("http://www.ietf.org/rfc/rfc2324.txt");
+            return Redirect("https://www.ietf.org/rfc/rfc2324.txt");
         }
 
         public ActionResult Index()

--- a/src/Teapot.Web/Models/StatusCodeResults.cs
+++ b/src/Teapot.Web/Models/StatusCodeResults.cs
@@ -65,7 +65,7 @@ namespace Teapot.Web.Models
                 Description = "Moved Permanently",
                 IncludeHeaders = new Dictionary<string, string>
                 {
-                    {"Location", "http://httpstat.us"}
+                    {"Location", "https://httpstat.us"}
                 }
             });
             Add(302, new StatusCodeResult
@@ -73,7 +73,7 @@ namespace Teapot.Web.Models
                 Description = "Found",
                 IncludeHeaders = new Dictionary<string, string>
                 {
-                    {"Location", "http://httpstat.us"}
+                    {"Location", "https://httpstat.us"}
                 }
             });
             Add(303, new StatusCodeResult
@@ -81,7 +81,7 @@ namespace Teapot.Web.Models
                 Description = "See Other",
                 IncludeHeaders = new Dictionary<string, string>
                 {
-                    {"Location", "http://httpstat.us"}
+                    {"Location", "https://httpstat.us"}
                 }
             });
             Add(304, new StatusCodeResult
@@ -94,7 +94,7 @@ namespace Teapot.Web.Models
                 Description = "Use Proxy",
                 IncludeHeaders = new Dictionary<string, string>
                 {
-                    {"Location", "http://httpstat.us"}
+                    {"Location", "https://httpstat.us"}
                 }
             });
             Add(306, new StatusCodeResult
@@ -106,7 +106,7 @@ namespace Teapot.Web.Models
                 Description = "Temporary Redirect",
                 IncludeHeaders = new Dictionary<string, string>
                 {
-                    {"Location", "http://httpstat.us"}
+                    {"Location", "https://httpstat.us"}
                 }
             });
             Add(308, new StatusCodeResult
@@ -114,9 +114,9 @@ namespace Teapot.Web.Models
                 Description = "Permanent Redirect",
                 IncludeHeaders = new Dictionary<string, string>
                 {
-                    {"Location", "http://httpstat.us"}
+                    {"Location", "https://httpstat.us"}
                 }
-            });            
+            });
             Add(400, new StatusCodeResult
             {
                 Description = "Bad Request"
@@ -200,7 +200,7 @@ namespace Teapot.Web.Models
             Add(418, new StatusCodeResult
             {
                 Description = "I'm a teapot",
-                Link = new Uri("http://www.ietf.org/rfc/rfc2324.txt")
+                Link = new Uri("https://www.ietf.org/rfc/rfc2324.txt")
             });
             Add(422, new StatusCodeResult
             {


### PR DESCRIPTION
This change makes `https://httpstat.us` (secure HTTPS) the Location URL for all
`https://httpstat.us/3xx` responses, rather than `http://httpstat.us/` (insecure
HTTP). Rationale: For any requests made to `https://httpstat.us/3xx` URLs from
frontend JavaScript running in a browser, the browser will block the request and
emit a “Mixed Content” error message. For a test case, see the last part of the
Stack Overflow answer at https://stackoverflow.com/a/46031800/441757