### PR TITLE
Editorial: Update some docs/comments URLs to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-This is the code for [httpstat.us](http://httpstat.us). More doco over there.
+This is the code for [httpstat.us](https://httpstat.us). More doco over there.
 
 Any changes pushed to the main repo (https://github.com/Readify/httpstatus) are auto-deployed to Windows Azure Websites.

--- a/src/Teapot.Web/Global.asax.cs
+++ b/src/Teapot.Web/Global.asax.cs
@@ -6,7 +6,7 @@ using System.Web.Routing;
 namespace Teapot.Web
 {
     // Note: For instructions on enabling IIS6 or IIS7 classic mode,
-    // visit http://go.microsoft.com/?LinkId=9394801
+    // visit https://go.microsoft.com/?LinkId=9394801
 
     public class MvcApplication : System.Web.HttpApplication
     {

--- a/src/Teapot.Web/Views/Shared/_Layout.cshtml
+++ b/src/Teapot.Web/Views/Shared/_Layout.cshtml
@@ -21,17 +21,17 @@
       </div>
       <footer>
         An
-        <a href='http://www.asp.net/mvc/mvc3'>ASP.NET MVC 3</a>
+        <a href='https://www.asp.net/mvc/mvc3'>ASP.NET MVC 3</a>
         +
-        <a href='http://weblogs.asp.net/scottgu/archive/2010/07/02/introducing-razor.aspx'>Razor</a>
+        <a href='https://weblogs.asp.net/scottgu/archive/2010/07/02/introducing-razor.aspx'>Razor</a>
         +
-        <a href='http://github.com/tathamoddie/teapot/'>Git</a>
+        <a href='https://github.com/tathamoddie/teapot/'>Git</a>
         +
-        <a href='http://windowsazure.com'>Windows Azure</a>
+        <a href='https://azure.microsoft.com'>Windows Azure</a>
         experiment by
-        <a href='http://www.aaron-powell.com'>Aaron Powell</a>
+        <a href='https://www.aaron-powell.com'>Aaron Powell</a>
         and
-        <a href='http://tath.am'>Tatham Oddie</a>
+        <a href='https://tath.am'>Tatham Oddie</a>
         .
       </footer>
       <script type='text/javascript'>

--- a/src/Teapot.Web/Web.Debug.config
+++ b/src/Teapot.Web/Web.Debug.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0"?>
 
-<!-- For more information on using web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=125889 -->
+<!-- For more information on using web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=125889 -->
 
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
   <!--

--- a/src/Teapot.Web/Web.Release.config
+++ b/src/Teapot.Web/Web.Release.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0"?>
 
-<!-- For more information on using web.config transformation visit http://go.microsoft.com/fwlink/?LinkId=125889 -->
+<!-- For more information on using web.config transformation visit https://go.microsoft.com/fwlink/?LinkId=125889 -->
 
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
   <!--


### PR DESCRIPTION
This is a minor editorial change that just replaces `http://` URLs in
some docs/comments with `https://` URLs. (It leaves the `http://`
schema-namespace identifiers unchanged, as it seems they should be.)