### PR TITLE
Extend status timeout from 5 minutes to 15 minutes

### DIFF
--- a/src/Teapot.Web/Controllers/StatusController.cs
+++ b/src/Teapot.Web/Controllers/StatusController.cs
@@ -11,7 +11,7 @@ namespace Teapot.Web.Controllers
         static readonly StatusCodeResults StatusCodes = new StatusCodeResults();
 
         private const int SLEEP_MIN = 0;
-        private const int SLEEP_MAX = 300000; // 5 mins in milliseconds
+        private const int SLEEP_MAX = 900000; // 15 mins in milliseconds
 
         public ActionResult Index()
         {


### PR DESCRIPTION
I have a use case where I need a slightly longer than 5 minute timeout. Do you think we could change this to 15 minutes?

Thanks
Chris