### PR TITLE
Give empty response if Accept not specified

### DIFF
--- a/src/Teapot.Web/CustomHttpStatusCodeResult.cs
+++ b/src/Teapot.Web/CustomHttpStatusCodeResult.cs
@@ -28,16 +28,17 @@ namespace Teapot.Web
             else
             {
                 var acceptTypes = context.HttpContext.Request.AcceptTypes;
-                if (acceptTypes != null && acceptTypes.Contains("application/json"))
-                {
-                    //Set the body to be the status code and description with a plain content type response
-                    context.HttpContext.Response.Write("\"" + StatusCode + " " + StatusDescription + "\"");
-                    context.HttpContext.Response.ContentType = "application/json";
-                } else
-                {
-                    //Set the body to be the status code and description with a plain content type response
-                    context.HttpContext.Response.Write(StatusCode + " " + StatusDescription);
-                    context.HttpContext.Response.ContentType = "text/plain";
+                if (acceptTypes != null) {
+                    if (acceptTypes.Contains("application/json")) {
+                        //Set the body to be the status code and description with a plain content type response
+                        context.HttpContext.Response.Write("\"" + StatusCode + " " + StatusDescription + "\"");
+                        context.HttpContext.Response.ContentType = "application/json";
+                    } else
+                    {
+                        //Set the body to be the status code and description with a plain content type response
+                        context.HttpContext.Response.Write(StatusCode + " " + StatusDescription);
+                        context.HttpContext.Response.ContentType = "text/plain";
+                    }
                 }
             }
 


### PR DESCRIPTION
If no `Accept` header present, don't write a response body

Allows for testing no response body