### PR TITLE
change 'doco' to documents and complete the sentence

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-This is the code for [httpstat.us](https://httpstat.us). More doco over there.
+This is the code for [httpstat.us](https://httpstat.us). More documentation can be found there.
 
 Any changes pushed to the main repo (https://github.com/Readify/httpstatus) are auto-deployed to Windows Azure Websites.


### PR DESCRIPTION
# Reason
Currently the READ.me says "More doco over there" and as a first time traveler to this repo I was caught a bit off guard. After thinking about it doco just meant documentation, so I'm proposing a different sentence.

# Implementation
Update the sentence.