### PR TITLE
Update CustomHttpStatusCodeResult.cs

### DIFF
--- a/src/Teapot.Web/CustomHttpStatusCodeResult.cs
+++ b/src/Teapot.Web/CustomHttpStatusCodeResult.cs
@@ -28,17 +28,15 @@ namespace Teapot.Web
             else
             {
                 var acceptTypes = context.HttpContext.Request.AcceptTypes;
-                if (acceptTypes != null) {
-                    if (acceptTypes.Contains("application/json")) {
-                        //Set the body to be the status code and description with a plain content type response
-                        context.HttpContext.Response.Write("\"" + StatusCode + " " + StatusDescription + "\"");
-                        context.HttpContext.Response.ContentType = "application/json";
-                    } else
-                    {
-                        //Set the body to be the status code and description with a plain content type response
-                        context.HttpContext.Response.Write(StatusCode + " " + StatusDescription);
-                        context.HttpContext.Response.ContentType = "text/plain";
-                    }
+                if (acceptTypes != null && acceptTypes.Contains("application/json")) {
+                    //Set the body to be the status code and description with a plain content type response
+                    context.HttpContext.Response.Write("\"" + StatusCode + " " + StatusDescription + "\"");
+                    context.HttpContext.Response.ContentType = "application/json";
+                } else
+                {
+                    //Set the body to be the status code and description with a plain content type response
+                    context.HttpContext.Response.Write(StatusCode + " " + StatusDescription);
+                    context.HttpContext.Response.ContentType = "text/plain";
                 }
             }
 


### PR DESCRIPTION
Give response a header: Response.ContentType = "text/plain"  even if the request  is not set header("Accept":"xxxxxxx")


When I get http://httpstat.us/500 using OkHttpClient
I excepted to get the body "500 Internal Server Error" , but I didn't
After analysis, it was found that the header was not set in the okhttpclient request like: header("Accept":"xxxxxxx")
OkHttpClient relies on the "content-type" of the response when getting the body
https://github.com/square/okhttp/blob/master/okhttp/src/main/java/okhttp3/internal/connection/Exchange.kt#L123

debug 1day in OkHttpClient ,Finally found this
merge it please,to help others