### PR TITLE
Respond object literals to JSON

### DIFF
--- a/src/Teapot.Web/CustomHttpStatusCodeResult.cs
+++ b/src/Teapot.Web/CustomHttpStatusCodeResult.cs
@@ -30,8 +30,8 @@ namespace Teapot.Web
                 var acceptTypes = context.HttpContext.Request.AcceptTypes;
                 if (acceptTypes != null) {
                     if (acceptTypes.Contains("application/json")) {
-                        //Set the body to be the status code and description with a plain content type response
-                        context.HttpContext.Response.Write("\"" + StatusCode + " " + StatusDescription + "\"");
+                        //Set the body to be the status code and description with a JSON object type response
+                        context.HttpContext.Response.Write("{\"code\": " + StatusCode + ", \"description\": \"" + StatusDescription + "\"}");
                         context.HttpContext.Response.ContentType = "application/json";
                     } else
                     {


### PR DESCRIPTION
Object literal is returned when the request is received by Accept header contains 'application/json'.

The current JSON response implementation returns plain text enclosed in double quotes.
This pull request changes the double quoted plain text to an object literal.
This will allow the JSON parser to parse the response correctly.
