### PR TITLE
Add 103 Early Hints [RFC8297]

### DIFF
--- a/src/Teapot.Web/Models/StatusCodeResults.cs
+++ b/src/Teapot.Web/Models/StatusCodeResults.cs
@@ -22,6 +22,15 @@ namespace Teapot.Web.Models
                 Description = "Processing",
                 ExcludeBody = true
             });
+            Add(103, new StatusCodeResult
+            {
+                Description = "Early Hints",
+                ExcludeBody = true,
+                IncludeHeaders = new Dictionary<string, string>
+                {
+                    {"Link", "</Content/main.css>; rel=preload"}
+                }
+            });
             Add(200, new StatusCodeResult
             {
                 Description = "OK",


### PR DESCRIPTION
New status code "103 Early Hints [RFC8297]"

RFC 8297 - An HTTP Status Code for Indicating Hints
https://tools.ietf.org/html/rfc8297