### PR TITLE
Drop 429 retry time from 1 hour to 5 seconds.

### DIFF
--- a/src/Teapot.Web/Models/StatusCodeResults.cs
+++ b/src/Teapot.Web/Models/StatusCodeResults.cs
@@ -240,7 +240,7 @@ namespace Teapot.Web.Models
                 Description = "Too Many Requests",
                 IncludeHeaders = new Dictionary<string, string>
                 {
-                    {"Retry-After", "3600"}
+                    {"Retry-After", "5"}
                 }
             });
             Add(431, new StatusCodeResult


### PR DESCRIPTION
An hour is completely unusable for unit tests. 5 seconds is still longer than I would like, but is a noticeable length for more interactive scenarios.