### PR TITLE
Update Dockerfile

### DIFF
--- a/src/Teapot.Web/Dockerfile
+++ b/src/Teapot.Web/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0.102-ca-patch-buster-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /src
 COPY ["Teapot.Web/Teapot.Web.csproj", "Teapot.Web/"]
 RUN dotnet restore "Teapot.Web/Teapot.Web.csproj"


### PR DESCRIPTION
This `5.0.102-ca-patch-buster-slim` tag is no longer needed and is no longer serviced.

Context: https://github.com/dotnet/dotnet-docker/issues/2742

As an aside, do you have any feedback on how .NET container images can be improved? Do they meet your expectations?