### PR TITLE
Ignore rest of status code url after status code

### DIFF
--- a/src/Teapot.Web/Controllers/StatusController.cs
+++ b/src/Teapot.Web/Controllers/StatusController.cs
@@ -21,6 +21,7 @@ namespace Teapot.Web.Controllers
         public IActionResult Noop() => new EmptyResult();
 
         [Route("{statusCode}", Name = "StatusCode")]
+        [Route("{statusCode}/{*wildcard}", Name = "StatusCodeWildcard")]
         public async Task<IActionResult> StatusCode(int statusCode, int? sleep)
         {
             var statusData = _statusCodes.ContainsKey(statusCode)


### PR DESCRIPTION
Add the ability to set the base url as a https://httpstat.us/xxx/ and return the desired status no matter the rest of the url. 

Currently, if we desire to test what happens when a third party returns a 500 in our test environment, we can not test this with httpstat.us. We have the base url configurable as that is environment specific, but the rest of the url path is hard coded. 
Example: 
`https://thirdpartytest.com/sales/yesterday => 200`
Want to test what happens when a 500 is returned. Instead a 404 is returned. 
`https://httpstat.us/500/sales/yesterday => 404`

Proposed change:
`https://httpstat.us/500/sales/yesterday => 500`